### PR TITLE
Set node version in python action

### DIFF
--- a/.framework/python/backend/app/db/repositories/items.py
+++ b/.framework/python/backend/app/db/repositories/items.py
@@ -266,7 +266,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
             self.connection,
             slug=slug,
         )
-        return [row["tag"] for row in tag_rows]
+        return sorted([row["tag"] for row in tag_rows])
 
     async def get_favorites_count_for_item_by_slug(self, *, slug: str) -> int:
         return (

--- a/.framework/python/backend/app/db/repositories/items.py
+++ b/.framework/python/backend/app/db/repositories/items.py
@@ -266,7 +266,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
             self.connection,
             slug=slug,
         )
-        return sorted([row["tag"] for row in tag_rows])
+        return [row["tag"] for row in tag_rows]
 
     async def get_favorites_count_for_item_by_slug(self, *, slug: str) -> int:
         return (

--- a/.framework/python/docker-compose.yml
+++ b/.framework/python/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             poetry export -f "requirements.txt" --without-hashes --with-credentials > "requirements.txt"
             /wait-for-it.sh postgres-python:5432 -q -t 60 && 
             poetry run alembic upgrade head &&
-            poetry run uvicorn --host=0.0.0.0 --port=3000 --reload app.main:app"
+            poetry run gunicorn app.main:app --worker-class=uvicorn.workers.UvicornWorker --bind=0.0.0.0:3000 --workers=5"
     working_dir: /usr/src
     volumes:
       - ./:/usr/src

--- a/.github/workflows/test_e2e_lint.yml
+++ b/.github/workflows/test_e2e_lint.yml
@@ -14,6 +14,13 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Run checks
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: tests/e2e/
+
       - run: yarn install
         working-directory: tests/e2e
 

--- a/.github/workflows/test_e2e_python.yml
+++ b/.github/workflows/test_e2e_python.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: tests/e2e/
 
       - run: yarn wait-on -v http-get://0.0.0.0:3000/health --timeout 5000
-        working-directory: tests/e2e/
+        working-directory: tests/e2e/yarn.lock
 
       - run: yarn test
         working-directory: tests/e2e/

--- a/.github/workflows/test_e2e_python.yml
+++ b/.github/workflows/test_e2e_python.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9.13"
+          cache: 'pip'
 
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
@@ -55,7 +56,7 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
-          cache-dependency-path: .framework/node/backend
+          cache-dependency-path: tests/e2e/
 
       - run: yarn install
         working-directory: tests/e2e/

--- a/.github/workflows/test_e2e_python.yml
+++ b/.github/workflows/test_e2e_python.yml
@@ -56,13 +56,13 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
-          cache-dependency-path: tests/e2e/
+          cache-dependency-path: tests/e2e/yarn.lock
 
       - run: yarn install
         working-directory: tests/e2e/
 
       - run: yarn wait-on -v http-get://0.0.0.0:3000/health --timeout 5000
-        working-directory: tests/e2e/yarn.lock
+        working-directory: tests/e2e/
 
       - run: yarn test
         working-directory: tests/e2e/

--- a/.github/workflows/test_e2e_python.yml
+++ b/.github/workflows/test_e2e_python.yml
@@ -50,6 +50,13 @@ jobs:
         run: ENGINE_BASE_URL=http://localhost:3003 WILCO_ID=0 SECRET_KEY=secret DATABASE_URL=postgresql://postgres:postgres@localhost/anythink-market  gunicorn app.main:app --worker-class=uvicorn.workers.UvicornWorker --bind=0.0.0.0:3000 --workers=5 >& /dev/null &
         working-directory: .framework/python/backend
 
+      - name: Run checks
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: .framework/node/backend
+
       - run: yarn install
         working-directory: tests/e2e/
 

--- a/.github/workflows/test_e2e_rails.yml
+++ b/.github/workflows/test_e2e_rails.yml
@@ -43,6 +43,13 @@ jobs:
       - run: ENGINE_BASE_URL=http://localhost:3003 WILCO_ID=0 DATABASE_URL=postgresql://postgres:postgres@localhost/anythink-market bin/rails s >& /dev/null &
         working-directory: .framework/rails/backend
 
+      - name: Run checks
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: tests/e2e/
+
       - run: yarn install
         working-directory: tests/e2e/
 

--- a/.github/workflows/test_e2e_rails.yml
+++ b/.github/workflows/test_e2e_rails.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
-          cache-dependency-path: tests/e2e/
+          cache-dependency-path: tests/e2e/yarn.lock
 
       - run: yarn install
         working-directory: tests/e2e/

--- a/tests/e2e/anytinkClient.js
+++ b/tests/e2e/anytinkClient.js
@@ -11,7 +11,7 @@ class AnythinkClient {
   constructor() {
     this.client = axios.create({
       baseURL: "http://localhost:3000",
-      timeout: 1000,
+      timeout: 2000,
     });
   }
 

--- a/tests/e2e/concurrent/items.test.js
+++ b/tests/e2e/concurrent/items.test.js
@@ -153,7 +153,7 @@ describe("Items Route", () => {
         user
       );
       expect(
-          matchObjects(updatedItemResult, {
+        matchObjects(updatedItemResult, {
           ...origItemInfo,
           ...updateInfo,
         })

--- a/tests/e2e/concurrent/items.test.js
+++ b/tests/e2e/concurrent/items.test.js
@@ -11,6 +11,7 @@ const {
   randomUserInfo,
   randomImageUrl,
   randomString,
+  matchObjects,
 } = require("../utils");
 
 let anythinkClient;
@@ -31,10 +32,11 @@ describe("Items Route", () => {
       const item = randomItemInfo();
 
       const createdItem = await anythinkClient.createItem(item, user);
-      expect(createdItem).toMatchObject(item);
+      expect(matchObjects(createdItem, item)).toBe(true);
 
       const receivedItem = await anythinkClient.getItem(createdItem.slug);
-      expect(receivedItem).toMatchObject(createdItem);
+
+      expect(matchObjects(receivedItem, createdItem)).toBe(true);
     });
 
     test("Can't create item without title", async () => {
@@ -150,14 +152,15 @@ describe("Items Route", () => {
         updateInfo,
         user
       );
-
-      expect(updatedItemResult).toMatchObject({
-        ...origItemInfo,
-        ...updateInfo,
-      });
+      expect(
+          matchObjects(updatedItemResult, {
+          ...origItemInfo,
+          ...updateInfo,
+        })
+      ).toBe(true);
 
       const retreivedItem = await anythinkClient.getItem(item.slug);
-      expect(retreivedItem).toMatchObject(updatedItemResult);
+      expect(matchObjects(retreivedItem, updatedItemResult)).toBe(true);
     };
   });
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,7 +7,7 @@
     "node": "16"
   },
   "scripts": {
-    "test": "yarn jest -c jest.concurrent.config.js --maxWorkers=100%",
+    "test": "yarn jest -c jest.sequential.config.js --maxWorkers=1 && yarn jest -c jest.concurrent.config.js --maxWorkers=100%",
     "format": "yarn prettier --write .",
     "lint": "yarn eslint . && yarn prettier -c ."
   },

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "test": "yarn jest -c jest.sequential.config.js --maxWorkers=1 && yarn jest -c jest.concurrent.config.js --maxWorkers=100%",
+    "test": "yarn jest -c jest.concurrent.config.js --maxWorkers=100%",
     "format": "yarn prettier --write .",
     "lint": "yarn eslint . && yarn prettier -c ."
   },

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "engines": {
+    "node": "16"
+  },
   "scripts": {
     "test": "yarn jest -c jest.concurrent.config.js --maxWorkers=100%",
     "format": "yarn prettier --write .",

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,3 +1,18 @@
+function matchObjects(obj1, obj2) {
+  if (!obj2) {
+    return true;
+  }
+  return Object.keys(obj2).every((key) => {
+    if (Array.isArray(obj1[key]) && Array.isArray(obj2[key])) {
+      return obj1[key].every((val) => obj2[key].includes(val));
+    } else if (typeof obj1[key] === "object" && typeof obj2[key] === "object") {
+      return matchObjects(obj1[key], obj2[key]);
+    } else {
+      return obj1[key] === obj2[key];
+    }
+  });
+}
+
 function randomString(length = 10) {
   const result = [];
   const characters = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -29,7 +44,7 @@ function randomItemInfo(info = null) {
     title: randomString(),
     description: randomString(),
     image: randomImageUrl(),
-    tagList: [randomString(), randomString()],
+    tagList: [randomString(), randomString()].sort(),
     ...info,
   };
 }
@@ -39,4 +54,5 @@ module.exports = {
   randomImageUrl,
   randomUserInfo,
   randomItemInfo,
+  matchObjects,
 };

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -44,7 +44,7 @@ function randomItemInfo(info = null) {
     title: randomString(),
     description: randomString(),
     image: randomImageUrl(),
-    tagList: [randomString(), randomString()].sort(),
+    tagList: [randomString(), randomString()],
     ...info,
   };
 }

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -2,6 +2,7 @@
 
 ## Anythink server
 1. Run the Anythink server, found in the `backend` directory. Make sure the following env vars are set: `ENGINE_BASE_URL=http://localhost:3003`, `WILCO_ID=0` and the `DB connection url`.
-    * For example, to test node server, go to relevant backend server,  run ```yarn install``` and `ENGINE_BASE_URL=http://localhost:3003 WILCO_ID=0 MONGODB_URI=mongodb://localhost/anythink-market yarn start`
+   * With Docker: Env vars can be set in the `docker-compose.yml` file, under the `backend` service. Make sure to set hostname to make sure docker can resolve the host. `- HOSTNAME=host.docker.internal`
+   * Without Docker: To test node server, go to relevant backend server,  run ```yarn install``` and `ENGINE_BASE_URL=http://localhost:3003 WILCO_ID=0 MONGODB_URI=mongodb://localhost/anythink-market yarn start`
 2. Run the tests in the /tests/e2e/ using `yarn test`
    To start the app use Docker. It will start both frontend and backend, including all the relevant dependencies, and the db.


### PR DESCRIPTION
# Description

We had our python test failing all of a sudden, fixed with the following changes:
* Set the node version in the github action to `16` (apperntly ubuntu image chaged to using `node 18`) - made the test work on the github machine
* Changed to python's docker compose  to use same run commands as the action (`gunicorn` that runs 5 `uvicorn` workers instead of just one standalone `uvicorn`) - made the tests work locally
* Increased test's Anythink client timeout
