### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,9 @@
     "workbench.welcomePage.walkthroughs.openOnInstall": false,
     "workbench.welcomePage.experimental.videoTutorials": "off",
     "github.codespaces.defaultExtensions": []
+    },
+  "features": {
+	  "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   }
+  
 }


### PR DESCRIPTION
Add docker in docker so we'll have docker running

We're now getting this error when trying to run `docker compose up`:
![image](https://github.com/trywilco/Anythink-Market-Public/assets/1804881/0778da2d-020c-4564-94d4-8c8370cc05a0)

![image](https://github.com/trywilco/Anythink-Market-Public/assets/1804881/08ef9a01-c8ab-41cd-9bef-2e18cacf119b)

That's because docker isn't running for some reason so we're using the [docker in docker](https://github.com/devcontainers/features/tree/main/src/docker-in-docker) feature