### PR TITLE
Update open_port script with retry mechanism

### DIFF
--- a/.devcontainer/open_port.sh
+++ b/.devcontainer/open_port.sh
@@ -1,1 +1,28 @@
-sleep 10 && gh codespace ports visibility 3000:public 3001:public -c $CODESPACE_NAME
+#!/bin/bash
+
+RETRY_COUNT=3
+RETRY_INTERVAL=5
+TARGET_PORTS=("3000" "3001")
+
+sleep 5
+
+for port in "${TARGET_PORTS[@]}"; do
+    for ((try = 1; try <= RETRY_COUNT; try++)); do
+        echo "Attempt $try: Making port $port public."
+
+        gh codespace ports visibility $port:public -c $CODESPACE_NAME
+        sleep 1
+
+        ports_json=$(gh codespace ports -c $CODESPACE_NAME --json label,sourcePort,visibility)
+        visibility=$(echo "$ports_json" | jq -r ".[] | select(.sourcePort == $port) | .visibility")
+
+        if [ "$visibility" == "public" ]; then
+            echo "Port $port is now public."
+            break
+        elif [ $try -lt $RETRY_COUNT ]; then
+            echo "Port $port is still not public. Retrying in $RETRY_INTERVAL seconds..."
+            sleep $RETRY_INTERVAL
+        else
+            echo "Failed to make port $port public after $RETRY_COUNT attempts."
+        fi
+    done

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,6 @@
 WILCO_ID="`cat .wilco`"
 ENGINE_EVENT_ENDPOINT="${ENGINE_BASE_URL}/users/${WILCO_ID}/event"
-CODESPACE_BACKEND_HOST="${CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+CODESPACE_BACKEND_HOST="${CODESPACE_NAME}-3000.preview.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
 CODESPACE_BACKEND_URL="https://${CODESPACE_BACKEND_HOST}"
 
 # Update engine that codespace started for user
@@ -11,6 +11,11 @@ echo "export CODESPACE_BACKEND_HOST=\"${CODESPACE_BACKEND_HOST}\"" >> ~/.bashrc
 echo "export CODESPACE_BACKEND_URL=\"${CODESPACE_BACKEND_URL}\"" >> ~/.bashrc
 echo "export CODESPACE_WDS_SOCKET_PORT=443" >> ~/.bashrc
 
+
+# Change backend port visibility to public
+echo "(&>/dev/null .devcontainer/open_port.sh &)" >> ~/.bashrc
+
+
 # Export welcome prompt in bash:
 echo "printf \"\n\n☁️☁️☁️️ Anythink: Develop in the Cloud ☁️☁️☁️\n\"" >> ~/.bashrc
 echo "printf \"\n=============================================\n\"" >> ~/.bashrc
@@ -18,6 +23,3 @@ echo "gh codespace ports -c $CODESPACE_NAME" >> ~/.bashrc
 echo "printf \"=============================================\n\"" >> ~/.bashrc
 echo "printf \"(Once docker-compose is up and running, you can access the frontend and backend using the above urls)\n\"" >> ~/.bashrc
 echo "printf \"\n\x1b[31m \x1b[1m👉 Type: \\\`docker-compose up\\\` to run the project. 👈\n\n\"" >> ~/.bashrc
-
-# Change backend port visibility to public
-echo "(&>/dev/null .devcontainer/open_port.sh &)" >> ~/.bashrc


### PR DESCRIPTION
# Description
Context:
* Github changed thr env param `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` to be `app.github.dev`
https://github.blog/changelog/2023-07-14-codespaces-port-forwarding-domain-name-updates/

  However, the github cli that opens the port affects only the url of the old format with includes the `.preview` as follows: 
`${CODESPACE_NAME}-3000.preview.app.github.dev`
So changed the anythink backend url to use this one instead on the new one which isn't affected by the cli.
So we need to wait for the cli to be updated...

* Added retry mechanism for opening the ports .

Thanks @darmalovan 