### PR TITLE
open port after start and not after creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
       "onAutoForward": "silent"
     }
   },
-  "postCreateCommand": "/bin/bash .devcontainer/setup.sh",
+  "postStartCommand": "bash -c .devcontainer/setup.sh",
 
   "settings": {
     "extensions.ignoreRecommendations": true,

--- a/.devcontainer/open_port.sh
+++ b/.devcontainer/open_port.sh
@@ -26,3 +26,4 @@ for port in "${TARGET_PORTS[@]}"; do
             echo "Failed to make port $port public after $RETRY_COUNT attempts."
         fi
     done
+done


### PR DESCRIPTION
# Description
Fixed bug in open port script.
Also change the call to it after docker start and not just after creation to prevent race conditions 
