### PR TITLE
chore: remove the `version` property as it's obsolete

### DIFF
--- a/.framework/java/docker-compose.yml
+++ b/.framework/java/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-java:
     build: ./backend

--- a/.framework/node/docker-compose.yml
+++ b/.framework/node/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-node:
     build: ./backend

--- a/.framework/python/docker-compose.yml
+++ b/.framework/python/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-python:
     build: ./backend

--- a/.framework/rails/docker-compose.yml
+++ b/.framework/rails/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-rails:
     build: ./backend


### PR DESCRIPTION
# Description

remove the `version` property as it's obsolete